### PR TITLE
not inherit App::FatPacker

### DIFF
--- a/META.json
+++ b/META.json
@@ -45,7 +45,6 @@
             "App::FatPacker" : "0",
             "App::cpanminus" : "0",
             "Perl::Strip" : "0",
-            "parent" : "0",
             "perl" : "5.008005"
          }
       },

--- a/cpanfile
+++ b/cpanfile
@@ -2,7 +2,6 @@ requires 'perl', '5.008005';
 requires 'App::FatPacker';
 requires 'Perl::Strip';
 requires 'App::cpanminus';
-requires 'parent';
 
 on test => sub {
     requires 'File::pushd';


### PR DESCRIPTION
In order not to depend on App::FatPacker internals,
we use only App::FatPacker::fatpack_code method.
