### PR TITLE
recognize multi-line shebang, as described in `perldoc perlrun`

### DIFF
--- a/lib/App/FatPacker/Simple.pm
+++ b/lib/App/FatPacker/Simple.pm
@@ -128,12 +128,15 @@ sub fatpack_file {
 sub load_main_script {
     my ($self, $file) = @_;
     open my $fh, "<", $file or die "Cannot open '$file': $!\n";
-    my ($shebang, $script) = ( scalar(<$fh>), join "", <$fh> );
-    if (index($shebang, '#!') != 0) {
-        $shebang = "";
-        $script  = $shebang . $script;
+    my @lines = <$fh>;
+    my @shebang;
+    if (@lines && index($lines[0], '#!') == 0) {
+        while (1) {
+            push @shebang, shift @lines;
+            last if $shebang[-1] =~ m{^\#\!.*perl};
+        }
     }
-    ($shebang, $script);
+    ((join "", @shebang), (join "", @lines));
 }
 
 sub load_file {


### PR DESCRIPTION
As described in `perldoc perlrun`, not only the first line is considered by the Perl interpreter as a shebang.  Actually, Perl interpreter ignores all lines until `#! perl`, if the first line starts with `#!`.  For example,

```
#! /bin/sh
exec perl -x $0 "$@"
#! perl
```

is considered a portable shebang in the sense that it does not hard-code the path of `perl` (note: POSIX-compliant systems are required to have `sh` under `/bin`).

This PR adjusts the `load_main_script` function so that App::FatPacker::Simple can recognize and handle such multi-line shebangs correctly.
